### PR TITLE
Fix: stabilize PR generation with structured output and gpt-5.4 integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [2.14.0] - 2026-03-10
+
+### Fixed
+
+- **PR content generation failure with gpt-5.4:**
+  - Replaced two parallel text API calls with a single structured output (JSON Schema) call
+  - Removed `maxCompletionTokens: 100` limit that caused empty responses with reasoning models
+  - Fixed double error notification when PR generation failed
+
+### Changed
+
+- **PR generation now uses structured output:**
+  - Uses `response_format: { type: 'json_schema' }` for reliable title/body extraction
+  - Single API call instead of two parallel calls for better stability
+  - No token limit on PR generation to accommodate reasoning model overhead
+- **Integration tests upgraded to gpt-5.4:**
+  - PR, commit message, and bullet list tests now use `gpt-5.4` with `developer` role
+  - Added commit message integration test suite (`commitMessage.integration.test.ts`)
+
 ## [2.13.0] - 2026-03-06
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,13 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Keep steering current and verify alignment with `/kiro:spec-status`
 - Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
 
+## API Integration Notes
+
+- PR generation uses **structured output** (`response_format: json_schema`) for reliable title/body extraction
+- Commit message generation uses **text completion** with `max_completion_tokens: 5000`
+- Model: `gpt-5.4` (reasoning model) — uses `developer` role, `reasoning_effort`, no `temperature`
+- Integration tests require `OPENAI_API_KEY` in `.env.local`
+
 ## Steering Configuration
 
 - Load entire `.kiro/steering/` as project memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otak-committer",
-  "version": "2.12.1",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "otak-committer",
-      "version": "2.12.1",
+      "version": "2.13.1",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/tsuyoshi-otake/otak-committer/issues"
   },
   "homepage": "https://github.com/tsuyoshi-otake/otak-committer#readme",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "overrides": {
     "minimatch": ">=10.2.3",
     "diff": ">=8.0.3",

--- a/src/__tests__/integration/commitMessage.integration.test.ts
+++ b/src/__tests__/integration/commitMessage.integration.test.ts
@@ -1,8 +1,8 @@
 /**
- * Integration test for useBulletList feature
+ * Integration test for Commit Message generation
  *
- * Verifies that the bullet list instruction in the prompt
- * produces commit messages with "- " prefixed lines in the body.
+ * Verifies that the commit message prompt produces correctly
+ * structured content when sent to the OpenAI API with gpt-5.4.
  *
  * Requires: OPENAI_API_KEY environment variable
  * Run with: OPENAI_API_KEY=sk-... npm run test:unit
@@ -19,8 +19,18 @@ import {
 } from '../../utils/conventionalCommits';
 
 /**
- * Character limits by style (mirrors MESSAGE_LENGTH_LIMITS in prompt.ts
- * without importing vscode-dependent module)
+ * System prompt matching src/languages/english.ts (PromptType.System)
+ * without importing vscode-dependent module.
+ */
+const SYSTEM_PROMPT = `You are an experienced software engineer assisting with project commit messages and PR creation.
+Your output has the following characteristics:
+
+- Clear and concise English
+- Technically accurate expressions
+- Appropriate summarization of changes`;
+
+/**
+ * Character limits by style (mirrors MESSAGE_LENGTH_LIMITS in prompt.ts)
  */
 const CHAR_LIMITS: Record<string, number> = {
     simple: 600,
@@ -30,7 +40,7 @@ const CHAR_LIMITS: Record<string, number> = {
 
 /**
  * Build a commit prompt identical to PromptService.createCommitPrompt
- * but without vscode.workspace.getConfiguration dependency.
+ * without vscode.workspace.getConfiguration dependency.
  */
 function buildCommitPrompt(
     diff: string,
@@ -74,51 +84,36 @@ ${options.useBulletList ? 'Format the body as follows: first write a brief summa
 DO NOT use any emojis in the content.`;
 }
 
-const SAMPLE_DIFF = `diff --git a/src/services/prompt.ts b/src/services/prompt.ts
---- a/src/services/prompt.ts
-+++ b/src/services/prompt.ts
-@@ -17,9 +17,9 @@
- export const MESSAGE_LENGTH_LIMITS = {
--    [MessageStyle.Simple]: 200,
--    ['normal']: 400,
--    [MessageStyle.Detailed]: 800,
-+    [MessageStyle.Simple]: 600,
-+    ['normal']: 1200,
-+    [MessageStyle.Detailed]: 2400,
- } as const;
-diff --git a/src/types/messageStyle.ts b/src/types/messageStyle.ts
---- a/src/types/messageStyle.ts
-+++ b/src/types/messageStyle.ts
-@@ -18,7 +18,7 @@
-     simple: {
-         tokens: {
--            commit: 100,
--            pr: 400,
-+            commit: 300,
-+            pr: 1200,
-         },
-     normal: {
-         tokens: {
--            commit: 200,
--            pr: 800,
-+            commit: 600,
-+            pr: 2400,
-         },`;
+const SAMPLE_DIFF = `diff --git a/src/services/auth.ts b/src/services/auth.ts
+--- a/src/services/auth.ts
++++ b/src/services/auth.ts
+@@ -10,6 +10,26 @@
+ export class AuthService {
++    private tokenCache: Map<string, string> = new Map();
++
++    async validateToken(token: string): Promise<boolean> {
++        if (this.tokenCache.has(token)) {
++            return true;
++        }
++        const isValid = await this.checkTokenWithServer(token);
++        if (isValid) {
++            this.tokenCache.set(token, Date.now().toString());
++        }
++        return isValid;
++    }
++
++    clearCache(): void {
++        this.tokenCache.clear();
++    }
+ }`;
 
-const SYSTEM_PROMPT = `You are an experienced software engineer assisting with project commit messages and PR creation.
-Your output has the following characteristics:
-
-- Clear and concise English
-- Technically accurate expressions
-- Appropriate summarization of changes`;
-
-suite('Bullet List Integration Tests', () => {
+suite('Commit Message Integration Tests', () => {
     const apiKey = process.env.OPENAI_API_KEY;
     const isValidApiKey =
         apiKey && apiKey.startsWith('sk-') && apiKey.length > 20 && !apiKey.includes('*');
 
-    test('useBulletList=true should produce bullet list body', async function () {
-        this.timeout(60000);
+    test('gpt-5.4 should generate a valid conventional commit message', async function () {
+        this.timeout(120000);
 
         if (!isValidApiKey) {
             console.log(
@@ -150,39 +145,35 @@ suite('Bullet List Integration Tests', () => {
             });
 
             const message = response.choices[0]?.message?.content?.trim();
-            console.log('=== useBulletList=true response ===');
+            console.log('=== Commit message (english, normal) ===');
             console.log(message);
-            console.log('===================================');
+            console.log('=========================================');
 
             assert.ok(message, 'Should return a commit message');
 
-            // The body (lines after the first line) should contain:
-            // 1. A prose summary (non-bullet lines)
-            // 2. Bullet points after the summary
-            const lines = message.split('\n').filter((l) => l.trim().length > 0);
-            const bodyLines = lines.slice(1); // skip subject line
-
-            const bulletLines = bodyLines.filter((l) => l.trim().startsWith('- '));
-            const proseLines = bodyLines.filter((l) => !l.trim().startsWith('- '));
-            console.log(
-                `Body lines: ${bodyLines.length}, Prose lines: ${proseLines.length}, Bullet lines: ${bulletLines.length}`,
-            );
-
+            // First line should match conventional commits pattern
+            const firstLine = message.split('\n')[0];
+            const conventionalPattern = /^(fix|feat|docs|style|refactor|perf|test|chore)(\(.+\))?:\s*.+/;
             assert.ok(
-                proseLines.length >= 1,
-                `Expected at least 1 prose summary line before bullets, got ${proseLines.length}. Body:\n${bodyLines.join('\n')}`,
+                conventionalPattern.test(firstLine),
+                `First line should match Conventional Commits format, got: "${firstLine}"`,
             );
+
+            // Should have a body
+            const lines = message.split('\n').filter((l) => l.trim().length > 0);
+            assert.ok(lines.length > 1, `Should have body lines, got ${lines.length} total lines`);
+
+            // Body should contain bullet points
+            const bodyLines = lines.slice(1);
+            const bulletLines = bodyLines.filter((l) => l.trim().startsWith('- '));
             assert.ok(
                 bulletLines.length >= 1,
-                `Expected at least 1 bullet line in body, got ${bulletLines.length}. Body:\n${bodyLines.join('\n')}`,
+                `Expected at least 1 bullet line, got ${bulletLines.length}`,
             );
 
-            console.log('✓ useBulletList=true integration test passed');
+            console.log(`✓ Commit message test passed (${lines.length} lines, ${bulletLines.length} bullets)`);
         } catch (error: unknown) {
-            if (
-                error instanceof OpenAI.APIError &&
-                error.status === 401
-            ) {
+            if (error instanceof OpenAI.APIError && error.status === 401) {
                 console.log('Skipping: Invalid API key (401)');
                 this.skip();
                 return;
@@ -191,8 +182,8 @@ suite('Bullet List Integration Tests', () => {
         }
     });
 
-    test('useBulletList=false should NOT require bullet list body', async function () {
-        this.timeout(60000);
+    test('gpt-5.4 should generate a simple style commit message', async function () {
+        this.timeout(120000);
 
         if (!isValidApiKey) {
             this.skip();
@@ -202,7 +193,7 @@ suite('Bullet List Integration Tests', () => {
         const openai = new OpenAI({ apiKey });
         const prompt = buildCommitPrompt(SAMPLE_DIFF, {
             language: 'english',
-            messageStyle: 'normal',
+            messageStyle: 'simple',
             useBulletList: false,
             useConventionalCommits: true,
         });
@@ -221,24 +212,19 @@ suite('Bullet List Integration Tests', () => {
             });
 
             const message = response.choices[0]?.message?.content?.trim();
-            console.log('=== useBulletList=false response ===');
+            console.log('=== Commit message (english, simple) ===');
             console.log(message);
-            console.log('====================================');
+            console.log('=========================================');
 
             assert.ok(message, 'Should return a commit message');
-
-            // Verify the prompt does NOT contain bullet list instruction
             assert.ok(
-                !prompt.includes('bullet list'),
-                'Prompt should not contain bullet list instruction when disabled',
+                message.length <= 600,
+                `Simple message should be under 600 chars, got ${message.length}`,
             );
 
-            console.log('✓ useBulletList=false integration test passed');
+            console.log(`✓ Simple commit message test passed (${message.length} chars)`);
         } catch (error: unknown) {
-            if (
-                error instanceof OpenAI.APIError &&
-                error.status === 401
-            ) {
+            if (error instanceof OpenAI.APIError && error.status === 401) {
                 this.skip();
                 return;
             }
@@ -246,8 +232,8 @@ suite('Bullet List Integration Tests', () => {
         }
     });
 
-    test('Conventional Commits format should be used when enabled', async function () {
-        this.timeout(60000);
+    test('gpt-5.4 should generate a Japanese commit message', async function () {
+        this.timeout(120000);
 
         if (!isValidApiKey) {
             this.skip();
@@ -256,7 +242,7 @@ suite('Bullet List Integration Tests', () => {
 
         const openai = new OpenAI({ apiKey });
         const prompt = buildCommitPrompt(SAMPLE_DIFF, {
-            language: 'english',
+            language: 'japanese',
             messageStyle: 'normal',
             useBulletList: true,
             useConventionalCommits: true,
@@ -276,9 +262,20 @@ suite('Bullet List Integration Tests', () => {
             });
 
             const message = response.choices[0]?.message?.content?.trim();
+            console.log('=== Commit message (japanese, normal) ===');
+            console.log(message);
+            console.log('==========================================');
+
             assert.ok(message, 'Should return a commit message');
 
-            // First line should match conventional commits pattern: type(scope): subject or type: subject
+            // Body should contain Japanese characters
+            const japanesePattern = /[\u3000-\u9FFF\uF900-\uFAFF]/;
+            assert.ok(
+                japanesePattern.test(message),
+                'Commit message should contain Japanese characters',
+            );
+
+            // First line should still have conventional commit prefix
             const firstLine = message.split('\n')[0];
             const conventionalPattern = /^(fix|feat|docs|style|refactor|perf|test|chore)(\(.+\))?:\s*.+/;
             assert.ok(
@@ -286,12 +283,9 @@ suite('Bullet List Integration Tests', () => {
                 `First line should match Conventional Commits format, got: "${firstLine}"`,
             );
 
-            console.log('✓ Conventional Commits format integration test passed');
+            console.log('✓ Japanese commit message test passed');
         } catch (error: unknown) {
-            if (
-                error instanceof OpenAI.APIError &&
-                error.status === 401
-            ) {
+            if (error instanceof OpenAI.APIError && error.status === 401) {
                 this.skip();
                 return;
             }

--- a/src/__tests__/integration/pr.integration.test.ts
+++ b/src/__tests__/integration/pr.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration test for PR (Pull Request) generation
  *
- * Verifies that the PR title and body prompts produce correctly
+ * Verifies that the PR structured output produces correctly
  * structured content when sent to the OpenAI API.
  *
  * Requires: OPENAI_API_KEY environment variable
@@ -97,35 +97,37 @@ ${f.patch}`,
 }
 
 /**
- * Build a PR title prompt identical to PromptService.createPRPrompt title
- * without vscode.workspace.getConfiguration dependency.
+ * JSON schema for structured PR output
  */
-function buildPRTitlePrompt(
-    diffSummary: string,
-    language: string,
-    useEmoji: boolean,
-): string {
-    return `Generate a Pull Request title in ${language}.
-
-Requirements:
-1. Title should be concise and accurately represent the changes
-2. Include a prefix (e.g., "Feature:", "Fix:", "Improvement:", etc.) ${useEmoji ? 'with appropriate emoji prefix' : 'without emoji'}
-3. Output ONLY the title text itself. Do not include labels like "Title:" or wrap in quotes.
-
-Git diff: ${diffSummary}`;
-}
+const PR_CONTENT_SCHEMA = {
+    type: 'object',
+    properties: {
+        title: { type: 'string', description: 'Pull request title with prefix' },
+        body: { type: 'string', description: 'Pull request body in markdown' },
+    },
+    required: ['title', 'body'],
+    additionalProperties: false,
+} as const;
 
 /**
- * Build a PR body prompt identical to PromptService.createPRPrompt body
+ * Build a combined PR prompt identical to PromptService.createPRPrompt
  * without vscode.workspace.getConfiguration dependency.
  */
-function buildPRBodyPrompt(
+function buildPRPrompt(
     diffSummary: string,
     language: string,
     useEmoji: boolean,
 ): string {
     const emojiInstruction = useEmoji ? '' : 'DO NOT use any emojis in the content. ';
-    return `Generate a detailed Pull Request description in ${language} for the following changes.
+    return `Generate a Pull Request title and body in ${language} for the following changes.
+
+Title requirements:
+1. Concise and accurately represents the changes
+2. Include a prefix (e.g., "Feature:", "Fix:", "Improvement:", etc.) ${useEmoji ? 'with appropriate emoji prefix' : 'without emoji'}
+3. Just the title text, no labels like "Title:" and no quotes
+
+Body requirements:
+Generate a detailed description with the following sections:
 
 # Overview
 - Brief explanation of implemented features or fixes
@@ -147,10 +149,8 @@ function buildPRBodyPrompt(
 - Impact on existing features
 - Required configuration or environment variables
 
-Git diff:
-${diffSummary}
-
-Note: Please ensure all content is written in ${language}. ${emojiInstruction}`;
+${emojiInstruction}Git diff:
+${diffSummary}`;
 }
 
 suite('PR Generation Integration Tests', () => {
@@ -160,7 +160,7 @@ suite('PR Generation Integration Tests', () => {
 
     const diffSummary = generateDiffSummary(SAMPLE_PR_DIFF);
 
-    test('PR title should contain a prefix keyword', async function () {
+    test('Structured output should return valid PR title and body', async function () {
         this.timeout(60000);
 
         if (!isValidApiKey) {
@@ -172,42 +172,62 @@ suite('PR Generation Integration Tests', () => {
         }
 
         const openai = new OpenAI({ apiKey });
-        const prompt = buildPRTitlePrompt(diffSummary, 'english', false);
+        const prompt = buildPRPrompt(diffSummary, 'english', false);
 
         try {
             const response = await openai.chat.completions.create({
-                model: 'gpt-4o-mini',
+                model: 'gpt-5.4',
                 messages: [
-                    { role: 'system', content: SYSTEM_PROMPT },
+                    { role: 'developer', content: SYSTEM_PROMPT },
                     { role: 'user', content: prompt },
                 ],
-                max_tokens: 100,
-                temperature: 0,
+                reasoning_effort: 'low',
+                response_format: {
+                    type: 'json_schema',
+                    json_schema: {
+                        name: 'pr_content',
+                        strict: true,
+                        schema: PR_CONTENT_SCHEMA,
+                    },
+                },
             });
 
-            const title = response.choices[0]?.message?.content?.trim();
-            console.log('=== PR title response ===');
-            console.log(title);
-            console.log('=========================');
+            const content = response.choices[0]?.message?.content?.trim();
+            assert.ok(content, 'Should return content');
 
-            assert.ok(title, 'Should return a PR title');
+            const result = JSON.parse(content) as { title: string; body: string };
 
-            // Title should start with a prefix keyword (no "Title:" label)
+            console.log('=== PR structured output ===');
+            console.log('Title:', result.title);
+            console.log('Body:', result.body.substring(0, 200) + '...');
+            console.log('============================');
+
+            assert.ok(result.title, 'Should return a PR title');
+            assert.ok(result.body, 'Should return a PR body');
+
+            // Title should start with a prefix keyword
             const prefixPattern =
                 /^(Feature|Fix|Improvement|Refactor|Chore|Docs|feat|fix|chore|docs|test|perf|style|refactor)\b/i;
-            const cleanTitle = title.replace(/^["']|["']$/g, '');
+            const cleanTitle = result.title.replace(/^["']|["']$/g, '');
             assert.ok(
                 prefixPattern.test(cleanTitle),
-                `PR title should start with a prefix keyword, got: "${title}"`,
+                `PR title should start with a prefix keyword, got: "${result.title}"`,
             );
 
-            // Verify no "Title:" label was included
+            // Body should be substantial
+            assert.ok(result.body.length > 100, `PR body should be substantial, got ${result.body.length} chars`);
+
+            // Body should contain expected markdown sections
+            const expectedSections = ['Overview', 'Key Review Points', 'Change Details', 'Additional Notes'];
+            const foundSections = expectedSections.filter((section) =>
+                new RegExp(`#.*${section}`, 'i').test(result.body),
+            );
             assert.ok(
-                !title.startsWith('Title:') && !title.startsWith('タイトル:'),
-                `PR title should not include a "Title:" label, got: "${title}"`,
+                foundSections.length >= 2,
+                `Expected at least 2 of 4 sections, found ${foundSections.length}: ${foundSections.join(', ')}`,
             );
 
-            console.log('✓ PR title prefix integration test passed');
+            console.log('✓ PR structured output integration test passed');
         } catch (error: unknown) {
             if (error instanceof OpenAI.APIError && error.status === 401) {
                 console.log('Skipping: Invalid API key (401)');
@@ -218,7 +238,7 @@ suite('PR Generation Integration Tests', () => {
         }
     });
 
-    test('PR body should contain expected markdown sections', async function () {
+    test('Structured output without emoji should not contain emojis', async function () {
         this.timeout(60000);
 
         if (!isValidApiKey) {
@@ -227,81 +247,40 @@ suite('PR Generation Integration Tests', () => {
         }
 
         const openai = new OpenAI({ apiKey });
-        const prompt = buildPRBodyPrompt(diffSummary, 'english', false);
+        const prompt = buildPRPrompt(diffSummary, 'english', false);
 
         try {
             const response = await openai.chat.completions.create({
-                model: 'gpt-4o-mini',
+                model: 'gpt-5.4',
                 messages: [
-                    { role: 'system', content: SYSTEM_PROMPT },
+                    { role: 'developer', content: SYSTEM_PROMPT },
                     { role: 'user', content: prompt },
                 ],
-                max_tokens: 2000,
-                temperature: 0,
+                reasoning_effort: 'low',
+                response_format: {
+                    type: 'json_schema',
+                    json_schema: {
+                        name: 'pr_content',
+                        strict: true,
+                        schema: PR_CONTENT_SCHEMA,
+                    },
+                },
             });
 
-            const body = response.choices[0]?.message?.content?.trim();
-            console.log('=== PR body response ===');
-            console.log(body);
-            console.log('========================');
+            const content = response.choices[0]?.message?.content?.trim();
+            assert.ok(content, 'Should return content');
 
-            assert.ok(body, 'Should return a PR body');
-            assert.ok(body.length > 100, `PR body should be substantial, got ${body.length} chars`);
-
-            const expectedSections = ['Overview', 'Key Review Points', 'Change Details', 'Additional Notes'];
-            const foundSections = expectedSections.filter((section) =>
-                new RegExp(`#.*${section}`, 'i').test(body),
-            );
-            console.log(`Found sections: ${foundSections.join(', ')}`);
-
-            assert.ok(
-                foundSections.length >= 2,
-                `Expected at least 2 of 4 sections, found ${foundSections.length}: ${foundSections.join(', ')}`,
-            );
-
-            console.log('✓ PR body sections integration test passed');
-        } catch (error: unknown) {
-            if (error instanceof OpenAI.APIError && error.status === 401) {
-                this.skip();
-                return;
-            }
-            throw error;
-        }
-    });
-
-    test('PR body without emoji should not contain emojis', async function () {
-        this.timeout(60000);
-
-        if (!isValidApiKey) {
-            this.skip();
-            return;
-        }
-
-        const openai = new OpenAI({ apiKey });
-        const prompt = buildPRBodyPrompt(diffSummary, 'english', false);
-
-        try {
-            const response = await openai.chat.completions.create({
-                model: 'gpt-4o-mini',
-                messages: [
-                    { role: 'system', content: SYSTEM_PROMPT },
-                    { role: 'user', content: prompt },
-                ],
-                max_tokens: 2000,
-                temperature: 0,
-            });
-
-            const body = response.choices[0]?.message?.content?.trim();
-            assert.ok(body, 'Should return a PR body');
+            const result = JSON.parse(content) as { title: string; body: string };
+            assert.ok(result.body, 'Should return a PR body');
 
             const emojiPattern =
                 /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u;
             assert.ok(
-                !emojiPattern.test(body),
+                !emojiPattern.test(result.body),
                 'PR body should not contain emojis when useEmoji=false',
             );
 
-            console.log('✓ PR body no-emoji integration test passed');
+            console.log('✓ PR structured output no-emoji integration test passed');
         } catch (error: unknown) {
             if (error instanceof OpenAI.APIError && error.status === 401) {
                 this.skip();
@@ -311,7 +290,7 @@ suite('PR Generation Integration Tests', () => {
         }
     });
 
-    test('PR title and body in Japanese should contain Japanese characters', async function () {
+    test('Structured output in Japanese should contain Japanese characters', async function () {
         this.timeout(60000);
 
         if (!isValidApiKey) {
@@ -320,107 +299,47 @@ suite('PR Generation Integration Tests', () => {
         }
 
         const openai = new OpenAI({ apiKey });
-        const titlePrompt = buildPRTitlePrompt(diffSummary, 'japanese', false);
-        const bodyPrompt = buildPRBodyPrompt(diffSummary, 'japanese', false);
+        const prompt = buildPRPrompt(diffSummary, 'japanese', false);
 
         try {
-            const [titleResponse, bodyResponse] = await Promise.all([
-                openai.chat.completions.create({
-                    model: 'gpt-4o-mini',
-                    messages: [
-                        { role: 'system', content: SYSTEM_PROMPT },
-                        { role: 'user', content: titlePrompt },
-                    ],
-                    max_tokens: 100,
-                    temperature: 0,
-                }),
-                openai.chat.completions.create({
-                    model: 'gpt-4o-mini',
-                    messages: [
-                        { role: 'system', content: SYSTEM_PROMPT },
-                        { role: 'user', content: bodyPrompt },
-                    ],
-                    max_tokens: 2000,
-                    temperature: 0,
-                }),
-            ]);
+            const response = await openai.chat.completions.create({
+                model: 'gpt-5.4',
+                messages: [
+                    { role: 'developer', content: SYSTEM_PROMPT },
+                    { role: 'user', content: prompt },
+                ],
+                reasoning_effort: 'low',
+                response_format: {
+                    type: 'json_schema',
+                    json_schema: {
+                        name: 'pr_content',
+                        strict: true,
+                        schema: PR_CONTENT_SCHEMA,
+                    },
+                },
+            });
 
-            const title = titleResponse.choices[0]?.message?.content?.trim();
-            const body = bodyResponse.choices[0]?.message?.content?.trim();
+            const content = response.choices[0]?.message?.content?.trim();
+            assert.ok(content, 'Should return content');
 
-            console.log('=== Japanese PR title ===');
-            console.log(title);
-            console.log('=== Japanese PR body ===');
-            console.log(body?.substring(0, 200) + '...');
-            console.log('========================');
+            const result = JSON.parse(content) as { title: string; body: string };
 
-            assert.ok(title, 'Should return a Japanese PR title');
-            assert.ok(body, 'Should return a Japanese PR body');
-            assert.ok(body.length > 50, 'Japanese PR body should be substantial');
+            console.log('=== Japanese PR structured output ===');
+            console.log('Title:', result.title);
+            console.log('Body:', result.body.substring(0, 200) + '...');
+            console.log('=====================================');
+
+            assert.ok(result.title, 'Should return a Japanese PR title');
+            assert.ok(result.body, 'Should return a Japanese PR body');
+            assert.ok(result.body.length > 50, 'Japanese PR body should be substantial');
 
             const japanesePattern = /[\u3000-\u9FFF\uF900-\uFAFF]/;
             assert.ok(
-                japanesePattern.test(body),
+                japanesePattern.test(result.body),
                 'PR body should contain Japanese characters',
             );
 
-            console.log('✓ Japanese PR generation integration test passed');
-        } catch (error: unknown) {
-            if (error instanceof OpenAI.APIError && error.status === 401) {
-                this.skip();
-                return;
-            }
-            throw error;
-        }
-    });
-
-    test('PR title and body generated in parallel should both succeed', async function () {
-        this.timeout(60000);
-
-        if (!isValidApiKey) {
-            this.skip();
-            return;
-        }
-
-        const openai = new OpenAI({ apiKey });
-        const titlePrompt = buildPRTitlePrompt(diffSummary, 'english', false);
-        const bodyPrompt = buildPRBodyPrompt(diffSummary, 'english', false);
-
-        try {
-            const [titleResponse, bodyResponse] = await Promise.all([
-                openai.chat.completions.create({
-                    model: 'gpt-4o-mini',
-                    messages: [
-                        { role: 'system', content: SYSTEM_PROMPT },
-                        { role: 'user', content: titlePrompt },
-                    ],
-                    max_tokens: 100,
-                    temperature: 0,
-                }),
-                openai.chat.completions.create({
-                    model: 'gpt-4o-mini',
-                    messages: [
-                        { role: 'system', content: SYSTEM_PROMPT },
-                        { role: 'user', content: bodyPrompt },
-                    ],
-                    max_tokens: 2000,
-                    temperature: 0,
-                }),
-            ]);
-
-            const title = titleResponse.choices[0]?.message?.content?.trim();
-            const body = bodyResponse.choices[0]?.message?.content?.trim();
-
-            assert.ok(
-                typeof title === 'string' && title.length > 0,
-                'Parallel PR title should be a non-empty string',
-            );
-            assert.ok(
-                typeof body === 'string' && body.length > 0,
-                'Parallel PR body should be a non-empty string',
-            );
-
-            console.log(`✓ Parallel PR generation: title=${title.length} chars, body=${body.length} chars`);
+            console.log('✓ Japanese PR structured output integration test passed');
         } catch (error: unknown) {
             if (error instanceof OpenAI.APIError && error.status === 401) {
                 this.skip();

--- a/src/commands/PRCommand.ts
+++ b/src/commands/PRCommand.ts
@@ -130,7 +130,7 @@ export class PRCommand extends BaseCommand {
         });
 
         if (!prContent) {
-            this.logger.error('Failed to generate PR content');
+            this.logger.warning('PR content generation returned empty');
             vscode.window.showErrorMessage(t('messages.failedToGeneratePR'));
             return undefined;
         }

--- a/src/services/openai.completion.ts
+++ b/src/services/openai.completion.ts
@@ -11,6 +11,18 @@ export interface TextCompletionRequest {
     signal?: AbortSignal;
 }
 
+export interface StructuredCompletionRequest {
+    openai: OpenAI;
+    model: string;
+    systemPrompt: string;
+    userPrompt: string;
+    reasoningEffort: 'low' | 'medium' | 'high' | undefined;
+    temperature?: number;
+    signal?: AbortSignal;
+    schemaName: string;
+    schema: Record<string, unknown>;
+}
+
 export function resolveTemperature(model: string, requested?: number): number | undefined {
     if (model.startsWith('gpt-5')) {
         return undefined;
@@ -39,4 +51,34 @@ export async function requestTextCompletion(request: TextCompletionRequest): Pro
     );
 
     return response.choices?.[0]?.message?.content?.trim();
+}
+
+export async function requestStructuredCompletion<T>(request: StructuredCompletionRequest): Promise<T | undefined> {
+    const response = await request.openai.chat.completions.create(
+        {
+            model: request.model,
+            messages: [
+                { role: 'developer', content: request.systemPrompt },
+                { role: 'user', content: request.userPrompt },
+            ],
+            ...(request.temperature !== undefined ? { temperature: request.temperature } : {}),
+            reasoning_effort: request.reasoningEffort,
+            response_format: {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.schemaName,
+                    strict: true,
+                    schema: request.schema,
+                },
+            },
+            store: false,
+        },
+        { timeout: REQUEST_TIMEOUT_MS, ...(request.signal ? { signal: request.signal } : {}) },
+    );
+
+    const content = response.choices?.[0]?.message?.content?.trim();
+    if (!content) {
+        return undefined;
+    }
+    return JSON.parse(content) as T;
 }

--- a/src/services/openai.ops.ts
+++ b/src/services/openai.ops.ts
@@ -8,7 +8,7 @@ import { formatMarkdown, cleanMarkdown } from '../utils';
 import { getPrompt } from '../languages/prompts';
 import type { SupportedLanguage } from '../languages';
 import { PromptType } from '../types/enums/PromptType';
-import { requestTextCompletion } from './openai.completion';
+import { requestTextCompletion, requestStructuredCompletion } from './openai.completion';
 
 interface OpenAIOpsContext {
     openai: OpenAI;
@@ -113,6 +113,16 @@ export async function summarizeChunkOp(
     }
 }
 
+const PR_CONTENT_SCHEMA = {
+    type: 'object',
+    properties: {
+        title: { type: 'string', description: 'Pull request title with prefix' },
+        body: { type: 'string', description: 'Pull request body in markdown' },
+    },
+    required: ['title', 'body'],
+    additionalProperties: false,
+} as const;
+
 export async function generatePRContentOp(
     context: OpenAIOpsContext,
     diff: PullRequestDiff,
@@ -120,41 +130,32 @@ export async function generatePRContentOp(
     template?: TemplateInfo,
 ): Promise<{ title: string; body: string } | undefined> {
     try {
-        context.logger.info('Generating PR content', { language });
+        context.logger.info('Generating PR content with structured output', { language });
 
-        const prompts = await context.promptService.createPRPrompt(diff, language, template);
+        const userPrompt = await context.promptService.createPRPrompt(diff, language, template);
         const systemPrompt = getPrompt(language as SupportedLanguage, PromptType.System);
         const temperature = context.getTemperature();
 
-        const [title, body] = await Promise.all([
-            requestTextCompletion({
-                openai: context.openai,
-                model: context.model,
-                systemPrompt,
-                userPrompt: prompts.title,
-                temperature,
-                reasoningEffort: context.getReasoningEffort(),
-                maxCompletionTokens: 100,
-            }),
-            requestTextCompletion({
-                openai: context.openai,
-                model: context.model,
-                systemPrompt,
-                userPrompt: prompts.body,
-                temperature,
-                reasoningEffort: context.getReasoningEffort(),
-                maxCompletionTokens: 2000,
-            }),
-        ]);
+        const result = await requestStructuredCompletion<{ title: string; body: string }>({
+            openai: context.openai,
+            model: context.model,
+            systemPrompt,
+            userPrompt,
+            temperature,
+            reasoningEffort: context.getReasoningEffort(),
+            schemaName: 'pr_content',
+            schema: PR_CONTENT_SCHEMA,
+        });
 
-        if (typeof title !== 'string' || !title || typeof body !== 'string' || !body) {
-            throw new Error('Failed to generate PR content');
+        if (!result || !result.title || !result.body) {
+            context.logger.warning('Empty PR content returned from API');
+            return undefined;
         }
 
         context.logger.info('PR content generated successfully');
         return {
-            title: cleanMarkdown(title),
-            body: formatMarkdown(body),
+            title: cleanMarkdown(result.title),
+            body: formatMarkdown(result.body),
         };
     } catch (error) {
         context.logger.error('Failed to generate PR content', error);

--- a/src/services/prompt.ts
+++ b/src/services/prompt.ts
@@ -220,7 +220,7 @@ ${file.patch}`,
         diff: PullRequestDiff,
         language: string,
         template?: TemplateInfo,
-    ): Promise<{ title: string; body: string }> {
+    ): Promise<string> {
         const diffSummary = await this.generateDiffSummary(diff);
         const useEmoji =
             vscode.workspace.getConfiguration('otakCommitter').get<boolean>('useEmoji') || false;
@@ -232,28 +232,19 @@ ${file.patch}`,
             ? `Additional requirements: ${customMessage}\n\n`
             : '';
 
-        const titlePrompt = `Generate a Pull Request title in ${language}.
-
-Requirements:
-1. Title should be concise and accurately represent the changes
+        const titleInstruction = `Title requirements:
+1. Concise and accurately represents the changes
 2. Include a prefix (e.g., "Feature:", "Fix:", "Improvement:", etc.) ${useEmoji ? 'with appropriate emoji prefix' : 'without emoji'}
-3. Output ONLY the title text itself. Do not include labels like "Title:" or wrap in quotes.
+3. Just the title text, no labels like "Title:" and no quotes`;
 
-${customInstruction}Git diff: ${diffSummary}`;
-
-        const bodyPrompt = template
-            ? `Based on the following template and Git diff, generate a pull request:
-
-NOTE: Generate the content in ${language}.
+        const bodyInstruction = template
+            ? `Body requirements:
+Follow the template format strictly.
 
 Template:
-${PromptService.sanitizeTemplateContent(template.content)}
-
-Git diff:
-${diffSummary}
-
-Please follow the template format strictly and ensure all content is in ${language}. ${emojiInstruction}${customInstruction}`
-            : `Generate a detailed Pull Request description in ${language} for the following changes.
+${PromptService.sanitizeTemplateContent(template.content)}`
+            : `Body requirements:
+Generate a detailed description with the following sections:
 
 # Overview
 - Brief explanation of implemented features or fixes
@@ -273,17 +264,16 @@ Please follow the template format strictly and ensure all content is in ${langua
 # Additional Notes
 - Deployment considerations
 - Impact on existing features
-- Required configuration or environment variables
+- Required configuration or environment variables`;
 
-Git diff:
-${diffSummary}
+        return `Generate a Pull Request title and body in ${language} for the following changes.
 
-Note: Please ensure all content is written in ${language}. ${emojiInstruction}${customInstruction}`;
+${titleInstruction}
 
-        return {
-            title: titlePrompt,
-            body: bodyPrompt,
-        };
+${bodyInstruction}
+
+${emojiInstruction}${customInstruction}Git diff:
+${diffSummary}`;
     }
 
     /**

--- a/src/test/run-unit-tests.ts
+++ b/src/test/run-unit-tests.ts
@@ -39,6 +39,10 @@ async function runUnitTests() {
         const prIntegrationTests = await glob('__tests__/integration/pr*.test.js', {
             cwd: testsRoot,
         });
+        const commitMessageIntegrationTests = await glob(
+            '__tests__/integration/commitMessage*.test.js',
+            { cwd: testsRoot },
+        );
         const issueIntegrationTests = await glob('__tests__/integration/issue*.test.js', {
             cwd: testsRoot,
         });
@@ -111,6 +115,7 @@ async function runUnitTests() {
             ...i18nIntegrationTests,
             ...bulletListIntegrationTests,
             ...prIntegrationTests,
+            ...commitMessageIntegrationTests,
             ...issueIntegrationTests,
             ...filteredRobustnessServiceTests,
             ...filteredRobustnessUtilTests,
@@ -127,6 +132,7 @@ async function runUnitTests() {
         console.log(`  - i18n integration tests: ${i18nIntegrationTests.length}`);
         console.log(`  - Bullet list integration tests: ${bulletListIntegrationTests.length}`);
         console.log(`  - PR integration tests: ${prIntegrationTests.length}`);
+        console.log(`  - Commit message integration tests: ${commitMessageIntegrationTests.length}`);
         console.log(`  - Issue integration tests: ${issueIntegrationTests.length}`);
         console.log(
             `  - Robustness tests: ${filteredRobustnessServiceTests.length + filteredRobustnessUtilTests.length + filteredRobustnessCommandTests.length}`,


### PR DESCRIPTION
# Overview

This PR fixes PR content generation failures observed with `gpt-5.4` by replacing the previous two-call title/body generation flow with a single structured output request using JSON Schema.

The main purpose of this change is to improve reliability when using reasoning models, which were returning empty or inconsistent results under the previous approach. As part of that work, the PR prompt flow was consolidated into one combined prompt, the restrictive PR token limit was removed, and logging was adjusted to avoid duplicate error reporting when generation fails.

Technically, the implementation introduces a reusable structured completion helper, updates PR generation to parse a typed `{ title, body }` response from the API, and aligns integration tests with the newer `gpt-5.4` request pattern using the `developer` role and reasoning-specific parameters.

# Key Review Points

- Verify the new structured output flow in `generatePRContentOp`, especially the JSON schema contract and fallback behavior when the API returns empty content.

- Review the prompt refactor in `PromptService.createPRPrompt` to confirm that both default PR descriptions and template-based PR generation still behave correctly.

- Confirm that removing the PR-specific `maxCompletionTokens` limit is acceptable for reasoning models and does not introduce unintended cost or latency issues.

- Check the updated logging and command handling to ensure empty responses now surface as a single user-facing error without duplicate internal error noise.

- Review live integration tests for stability, since they now depend on `gpt-5.4` behavior and require a valid `OPENAI_API_KEY`.

# Change Details

- Reworked PR generation to use a single structured output API call instead of parallel text completions for title and body.

- Added `requestStructuredCompletion` in `src/services/openai.completion.ts` to support JSON Schema based responses.

- Updated `src/services/openai.ops.ts`:

- added a `PR_CONTENT_SCHEMA`

- switched PR generation to structured output

- removed the previous split request logic and fixed handling of empty API responses

- Updated `src/services/prompt.ts`:

- changed PR prompt creation to return one combined prompt string

- embedded explicit title and body requirements into a single request

- preserved template support while adapting it to the unified prompt flow

- Updated `src/commands/PRCommand.ts` to log empty PR generation as a warning instead of an error before showing the user-facing failure message.

- Expanded and updated integration coverage:

- migrated PR integration tests to structured output with `gpt-5.4`

- migrated bullet list integration tests to `gpt-5.4`, `developer` role, and reasoning-compatible parameters

- added a new `commitMessage.integration.test.ts` suite covering conventional commits, simple style output, and Japanese output

- updated `src/test/run-unit-tests.ts` to include the new commit message integration tests

- Updated documentation and release notes in `CHANGELOG.md` and `CLAUDE.md` to reflect the new API usage and testing requirements.

- Dependency changes:

- no new runtime dependencies were added

- `package.json` and `package-lock.json` were updated for the `2.14.0` version bump

# Additional Notes

- Deployment considerations:

- no special deployment steps are required beyond releasing the updated extension/package version

- behavior now depends on structured output support from the configured OpenAI model

- Impact on existing features:

- PR generation is the main affected feature and should be more stable with reasoning models

- commit message and bullet list generation were not functionally redesigned, but their integration tests were updated to match the current model/API usage

- template-based PR generation should continue to work, but it is worth reviewing because prompt assembly changed significantly

- Required configuration or environment variables:

- integration tests require `OPENAI_API_KEY` in the environment, typically via `.env.local`

- the updated test flow assumes `gpt-5.4` and the `developer` role with `reasoning_effort`

- no new application-level configuration keys were introduced

Resolves #3